### PR TITLE
Make ReleaseTools support annotated tags

### DIFF
--- a/release
+++ b/release
@@ -341,7 +341,7 @@ else
 fi;
 
 HEAD_REF=$(git rev-parse --verify HEAD)
-TAG_REF=$(git rev-parse --verify "$TAG")
+TAG_REF=$(git rev-parse --verify "$TAG^{}")
 
 if [ "x$TAG_REF" != "x$HEAD_REF" ] ; then
     error "tag $TAG is not the HEAD commit -- did you tag the right commit?"


### PR DESCRIPTION
Annotated tags have their own commit ref, which makes releasetools think the tag is not the HEAD commit. Adding ^{} to the tag makes git dereference the tag (if it is annotated) to get the underlying commit.