### PR TITLE
Delete .clang-format file in archive

### DIFF
--- a/release
+++ b/release
@@ -374,6 +374,7 @@ cd "$TMP_DIR/$BASENAME"
 notice "Removing unnecessary files"
 rm -f .git* .hg* .cvs*
 rm -f .appveyor.yml .codecov.yml .travis.yml
+rm -f .clang-format
 
 # execute .release script, if present
 if [ -f .release ] ; then


### PR DESCRIPTION
I recently released `curlInterface-2.0.1`, and @alex-konovalov suggested that I might want to exclude my `.clang-format` file from the archive in future releases.  This seems reasonable to me, since people using non-`git clone` versions are unlikely to be doing serious editing of the code.

I thought I'd share this, unless anyone can think of a reason that `.clang-format` files should be included in archives.

(I can see 4 packages in the standard distribution that have such a file included: anupq, curlInterface, kbmag, and io)