### PR TITLE
fix a few typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ executable.
    In particular, test the release archives created by the previous step. If
    you are unhappy with the outcome, or for some other reason decide that you
    need more changes, do these and go back and repeat previous steps as
-   necessary (in step 8, you now need to pass `--force` to the
+   necessary (in step 7, you now need to pass `--force` to the
    `release-gap-package` tool)
 
 9. Update the website:

--- a/release-gap-package
+++ b/release-gap-package
@@ -111,7 +111,7 @@ run_gap() {
 }
 
 # helper function for parsing GitHub's JSON output. Right now,
-# we only extra the value of a single key at a time. This means
+# we only extract the value of a single key at a time. This means
 # we may end up parsing the same JSON data two times, but that
 # doesn't really matter as it is tiny.
 json_get_key() {
@@ -469,7 +469,7 @@ fi
 
 cd "$SRC_DIR"
 
-# construct GitHub URL for pusing
+# construct GitHub URL for pushing
 REMOTE="https://$GITHUB_USER:$TOKEN@github.com/$REPO"
 
 # Make sure the branch is on the server


### PR DESCRIPTION
In the readme, step 8 refers to step 8 instead of step 7. In the script there are a few missing letters in the comments, "pusing" -> "pushing", "extra" -> "extract".