### PR TITLE
Use $REMOTE when pushing gh-pages

### DIFF
--- a/release-gap-package
+++ b/release-gap-package
@@ -605,7 +605,7 @@ git commit -m "Update website for $PKG $VERSION"
 
 if [ "x$PUSH" = xyes ] ; then
     notice "Pushing website changes"
-    git push
+    git push "$REMOTE"
     notice "Done"
     notice "Your PackageInfo.g is now at $PackageInfoURL"
 else


### PR DESCRIPTION
This allows to use the script in cases where no ssh key is configured, e.g. in CI environments.