### PR TITLE
Better support for monorepos

### DIFF
--- a/release-gap-package
+++ b/release-gap-package
@@ -48,6 +48,7 @@ Paths
   --srcdir <path>                  path of directory containing PackageInfo.g [Default: current directory]
   --tmpdir <path>                  path of temporary directory [Default: tmp subdirectory of srcdir]
   --webdir <path>                  path of web directory [Default: gh-pages subdirectory of srcdir]
+  --update-file <file>             path of the update.g file [Default: update.g in webdir]
 
 Custom settings
   --token <oauth>                  GitHub access token
@@ -143,10 +144,12 @@ while [ x"$1" != x ]; do
     --srcdir ) SRC_DIR="$1"; shift ;;
     --webdir ) WEB_DIR="$1"; shift ;;
     --tmpdir ) TMP_DIR="$1"; shift ;;
+    --update-file ) UPDATE_FILE="$1"; shift ;;
 
     --srcdir=*) SRC_DIR=${option#--srcdir=}; shift ;;
     --webdir=*) WEB_DIR=${option#--webdir=}; shift ;;
     --tmpdir=*) TMP_DIR=${option#--tmpdir=}; shift ;;
+    --update-file=*) UPDATE_FILE=${option#--update-file=}; shift ;;
 
     --token ) TOKEN="$1"; shift ;;
 
@@ -179,6 +182,14 @@ if [ "x$WEB_DIR" = x ] ; then
 fi
 if [ ! -d "$WEB_DIR" ] ; then
     error "could not find 'webdir' with clone of your gh-pages branch"
+fi
+
+# Check for presence of update.g file
+if [ "x$UPDATE_FILE" = x ] ; then
+    UPDATE_FILE="$WEB_DIR/update.g"
+fi
+if [ ! -f "$UPDATE_FILE" ] ; then
+    error "could not find update.g file"
 fi
 
 # Check whether GAP is usable
@@ -598,7 +609,7 @@ for f in ./*/*.htm* ; do
 done
 
 run_gap <<GAPInput
-Read("update.g");
+Read("$UPDATE_FILE");
 GAPInput
 
 git add -A .

--- a/release-gap-package
+++ b/release-gap-package
@@ -172,6 +172,8 @@ done
 # Some initial sanity checks
 #
 
+cd "$SRC_DIR"
+
 if [ ! -f PackageInfo.g ] ; then
     error "unable to read PackageInfo.g file, use --help for instructions"
 fi

--- a/release-gap-package
+++ b/release-gap-package
@@ -195,7 +195,7 @@ if [ "x$UPDATE_FILE" = x ] ; then
     UPDATE_FILE="$WEB_DIR/update.g"
 fi
 if [ ! -f "$UPDATE_FILE" ] ; then
-    error "could not find update.g file"
+    error "could not find update file \"${UPDATE_FILE}\""
 fi
 
 # Check whether GAP is usable

--- a/release-gap-package
+++ b/release-gap-package
@@ -49,7 +49,7 @@ Paths
   --srcdir <path>                  path of directory containing PackageInfo.g [Default: current directory]
   --tmpdir <path>                  path of temporary directory [Default: tmp subdirectory of srcdir]
   --webdir <path>                  path of web directory [Default: gh-pages subdirectory of srcdir]
-  --update-file <file>             path of the update.g file [Default: update.g in webdir]
+  --update-script <file>           path of the update script [Default: update.g in webdir]
 
 Custom settings
   --token <oauth>                  GitHub access token
@@ -146,12 +146,12 @@ while [ x"$1" != x ]; do
     --srcdir ) SRC_DIR="$1"; shift ;;
     --webdir ) WEB_DIR="$1"; shift ;;
     --tmpdir ) TMP_DIR="$1"; shift ;;
-    --update-file ) UPDATE_FILE="$1"; shift ;;
+    --update-script ) UPDATE_SCRIPT="$1"; shift ;;
 
     --srcdir=*) SRC_DIR=${option#--srcdir=}; shift ;;
     --webdir=*) WEB_DIR=${option#--webdir=}; shift ;;
     --tmpdir=*) TMP_DIR=${option#--tmpdir=}; shift ;;
-    --update-file=*) UPDATE_FILE=${option#--update-file=}; shift ;;
+    --update-script=*) UPDATE_SCRIPT=${option#--update-script=}; shift ;;
 
     --token ) TOKEN="$1"; shift ;;
 
@@ -190,12 +190,12 @@ if [ ! -d "$WEB_DIR" ] ; then
     error "could not find 'webdir' with clone of your gh-pages branch"
 fi
 
-# Check for presence of update.g file
-if [ "x$UPDATE_FILE" = x ] ; then
-    UPDATE_FILE="$WEB_DIR/update.g"
+# Check for presence of the update script
+if [ "x$UPDATE_SCRIPT" = x ] ; then
+    UPDATE_SCRIPT="$WEB_DIR/update.g"
 fi
-if [ ! -f "$UPDATE_FILE" ] ; then
-    error "could not find update file \"${UPDATE_FILE}\""
+if [ ! -f "$UPDATE_SCRIPT" ] ; then
+    error "could not find update script \"${UPDATE_SCRIPT}\""
 fi
 
 # Check whether GAP is usable
@@ -625,7 +625,7 @@ for f in ./*/*.htm* ; do
 done
 
 run_gap <<GAPInput
-Read("$UPDATE_FILE");
+Read("$UPDATE_SCRIPT");
 GAPInput
 
 git add -A

--- a/release-gap-package
+++ b/release-gap-package
@@ -43,6 +43,7 @@ Actions
   -p,  --push                      perform the final push, completing the release [Default]
   -P,  --no-push                   do not perform the final push
   -f,  --force                     if a release with the same name already exists: overwrite it
+  --skip-existing-release          if a release with the same name already exists: exit without error
 
 Paths
   --srcdir <path>                  path of directory containing PackageInfo.g [Default: current directory]
@@ -136,6 +137,7 @@ README_URL=
 PUSH=yes
 FORCE=no
 ONLY_TARBALL=no
+SKIP_EXISTING_RELEASE=no
 while [ x"$1" != x ]; do
   option="$1" ; shift
   case "$option" in
@@ -160,6 +162,8 @@ while [ x"$1" != x ]; do
     --no-force ) FORCE=no ;;
 
     --only-tarball ) ONLY_TARBALL=yes ;;
+
+    --skip-existing-release ) SKIP_EXISTING_RELEASE=yes ;;
 
     -- ) break ;;
     * ) error "unknown option '$option'" ;;
@@ -330,7 +334,7 @@ UPLOAD_URL=https://uploads.github.com/repos/$REPO/releases
 
 ######################################################################
 #
-# Determine the tag, and validate it
+# Determine the tag
 #
 verify_git_clean
 
@@ -341,6 +345,38 @@ else
     git tag "$TAG"
 fi;
 
+######################################################################
+#
+# Check if a GitHub release for this tag already exists
+#
+response=$(curl -s -S -X GET "$API_URL/tags/$TAG" -H "Authorization: token $TOKEN")
+MESSAGE=$(json_get_key message)
+RELEASE_ID=$(json_get_key id)
+
+if [ "$MESSAGE" = "Not Found" ] ; then
+    MESSAGE=  # release does not yet exist -> that's how we like it
+elif [ x"$RELEASE_ID" != x ] ; then
+    # release already exists -> skip, error out or delete it
+    if [ "x$SKIP_EXISTING_RELEASE" = xyes ] ; then
+        notice "release $TAG already exists on GitHub, skipping release"
+        exit 0
+    elif [ "x$FORCE" = xyes ] ; then
+        notice "Deleting existing release $TAG from GitHub"
+        response=$(curl --fail -s -S -X DELETE "$API_URL/$RELEASE_ID" -H "Authorization: token $TOKEN")
+        MESSAGE=
+    else
+        error "release $TAG already exists on GitHub, aborting (use --force to override this)"
+    fi
+fi
+
+if [ x"$MESSAGE" != x ] ; then
+    error "accessing GitHub failed: $MESSAGE"
+fi
+
+######################################################################
+#
+# Validate the tag
+#
 HEAD_REF=$(git rev-parse --verify HEAD)
 TAG_REF=$(git rev-parse --verify "$TAG^{}")
 
@@ -503,28 +539,6 @@ fi
 #
 # Create the GitHub release
 #
-
-# check if release already exists
-response=$(curl -s -S -X GET "$API_URL/tags/$TAG" -H "Authorization: token $TOKEN")
-MESSAGE=$(json_get_key message)
-RELEASE_ID=$(json_get_key id)
-
-if [ "$MESSAGE" = "Not Found" ] ; then
-    MESSAGE=  # release does not yet exist -> that's how we like it
-elif [ x"$RELEASE_ID" != x ] ; then
-    # release already exists -> error out or delete it
-    if [ "x$FORCE" = xyes ] ; then
-        notice "Deleting existing release $TAG from GitHub"
-        response=$(curl --fail -s -S -X DELETE "$API_URL/$RELEASE_ID" -H "Authorization: token $TOKEN")
-        MESSAGE=
-    else
-        error "release $TAG already exists on GitHub, aborting (use --force to override this)"
-    fi
-fi
-
-if [ x"$MESSAGE" != x ] ; then
-    error "accessing GitHub failed: $MESSAGE"
-fi
 
 # Create the release by sending suitable JSON
 DATA=$(cat <<EOF

--- a/release-gap-package
+++ b/release-gap-package
@@ -628,7 +628,7 @@ run_gap <<GAPInput
 Read("$UPDATE_FILE");
 GAPInput
 
-git add -A .
+git add -A
 git commit -m "Update website for $PKG $VERSION"
 
 if [ "x$PUSH" = xyes ] ; then

--- a/release-gap-package
+++ b/release-gap-package
@@ -544,7 +544,7 @@ fi
 DATA=$(cat <<EOF
 {
   "tag_name": "$TAG",
-  "name": "$VERSION",
+  "name": "$PKG $VERSION",
   "body": "Release for $PKG",
   "draft": false,
   "prerelease": false


### PR DESCRIPTION
Various changes which improve the support for monorepos like https://github.com/homalg-project/homalg_project. The existing behavior for normal repos should be essentially unchanged.

See commit messages for details. Regarding the forth commit: This situation happens for our monorepos because our `package.yml` files are actually symlinks which point outside of WEB_DIR: https://github.com/homalg-project/homalg_project/blob/gh-pages/4ti2Interface/_data/package.yml