### PR TITLE
Website manual: use absolute URLs for GAPDoc

### DIFF
--- a/release-gap-package
+++ b/release-gap-package
@@ -637,12 +637,15 @@ if [ -d "$TMP_DIR/$BASENAME/htm" ] ; then
     cp -r "$TMP_DIR/$BASENAME/htm" .
 fi
 
-# adjust links to the GAP manuals
+# adjust links to the GAP manuals and to the GAPDoc manuals.
 # Note that we cannot use sed's `-i` option for in-place editing, as
 # that is a non-portable extension of POSIX, which works differently in
 # BSD and GNU make.
 for f in ./*/*.htm* ; do
-  sed 's;href="../../../doc/;href="https://www.gap-system.org/Manuals/doc/;g' "$f" > "$f.bak"
+  sed \
+    -e 's;href="../../../doc/;href="https://www.gap-system.org/Manuals/doc/;g' \
+    -e 's;href="../../../pkg/GAPDoc[^\/]*/doc/;href="http://www.math.rwth-aachen.de/~Frank.Luebeck/GAPDoc/doc/;gi' \
+    "$f" > "$f.bak"
   mv "$f.bak" "$f"
 done
 


### PR DESCRIPTION
This relates to #73.

Currently, in the HTML version of the manual uploaded to the website, relative links to GAP are replaced with absolute URLs. This means that the links actually resolve.

For `gap-packages` packages linking relatively to other `gap-packages` packages, such fiddling might not be necessary. But since `GAPDoc` is not hosted under the `gap-packages` organisation, and since it is a particularly important package, I think it is work adding a special case for GAPDoc, too.

Although this is obviously not a complete solution for anything, I think it at least makes the situation better. In particular, it is useful for the Digraphs package.