### PR TITLE
Test for unresolved references when compiling the manual via `makedoc.g`

### DIFF
--- a/release-gap-package
+++ b/release-gap-package
@@ -268,11 +268,14 @@ esac
 if [ -f makedoc.g ] ; then
     notice "Building GAP package documentation (using makedoc.g)"
     run_gap <<GAPInput
+LogTo("makedoc.log");
 if not IsPackageMarkedForLoading("$PKG", "") then
   SetPackagePath("$PKG", ".");
 fi;
 Read("makedoc.g");
 GAPInput
+    ! grep -E "WARNING: non resolved reference" makedoc.log >/dev/null 2>&1 || error "non resolved reference(s) found in the manual"
+    rm -f makedoc.log
 elif [ -f doc/make_doc ] ; then
     notice "Building GAP package documentation (using doc/make_doc)"
     cd doc && ./make_doc && cd ..
@@ -417,12 +420,15 @@ cd "$TMP_DIR/$BASENAME"
 if [ -f makedoc.g ] ; then
     notice "Building GAP package documentation for archives (using makedoc.g)"
     run_gap <<GAPInput
+LogTo("makedoc.log");
 if not IsPackageMarkedForLoading("$PKG", "") then
   SetPackagePath("$PKG", ".");
 fi;
 PushOptions(rec(relativePath:="../../.."));
 Read("makedoc.g");
 GAPInput
+    ! grep -E "WARNING: non resolved reference" makedoc.log >/dev/null 2>&1 || error "non resolved reference(s) found in the manual"
+    rm -f makedoc.log
     rm -f doc/*.tex
     rm -f doc/*.aux doc/*.bbl doc/*.blg doc/*.brf doc/*.idx doc/*.ilg doc/*.ind doc/*.log doc/*.out doc/*.pnr doc/*.tst
 elif [ -f doc/make_doc ] ; then


### PR DESCRIPTION
This is a proposal; I saw that @james-d-mitchell had added such a think to the Semigroups package's `.release` script, and I thought it was a good idea.

As a first step before investing any further work on this: do you think it's a good idea as a general feature? Could you imagine wanting to include this, possibly only enabled by an option?