### PR TITLE
Run `.release` after building the manual

### DIFF
--- a/release-gap-package
+++ b/release-gap-package
@@ -409,6 +409,24 @@ git archive --prefix="$BASENAME/" "$TAG" . | tar xf - -C "$TMP_DIR"
 # Build the package documentation, run autoconf, etc.
 cd "$TMP_DIR/$BASENAME"
 
+if [ -f makedoc.g ] ; then
+    notice "Building GAP package documentation for archives (using makedoc.g)"
+    run_gap <<GAPInput
+if not IsPackageMarkedForLoading("$PKG", "") then
+  SetPackagePath("$PKG", ".");
+fi;
+PushOptions(rec(relativePath:="../../.."));
+Read("makedoc.g");
+GAPInput
+    rm -f doc/*.tex
+    rm -f doc/*.aux doc/*.bbl doc/*.blg doc/*.brf doc/*.idx doc/*.ilg doc/*.ind doc/*.log doc/*.out doc/*.pnr doc/*.tst
+elif [ -f doc/make_doc ] ; then
+    notice "Copying GAP package documentation for archives (using doc/make_doc)"
+    cp -r "$SRC_DIR/doc" .
+    cp -r "$SRC_DIR/htm" .
+    rm -f doc/*.aux doc/*.bbl doc/*.blg doc/*.brf doc/*.idx doc/*.ilg doc/*.ind doc/*.log doc/*.out doc/*.pnr doc/*.tst
+fi
+
 notice "Removing unnecessary files"
 # Remove recursively in case there is a .github directory
 rm -rf .git* .hg* .cvs* .circleci
@@ -431,24 +449,6 @@ if [ -x autogen.sh ] ; then
     notice "Generating build system files"
     sh autogen.sh
     rm -rf autom4te.cache
-fi
-
-if [ -f makedoc.g ] ; then
-    notice "Building GAP package documentation for archives (using makedoc.g)"
-    run_gap <<GAPInput
-if not IsPackageMarkedForLoading("$PKG", "") then
-  SetPackagePath("$PKG", ".");
-fi;
-PushOptions(rec(relativePath:="../../.."));
-Read("makedoc.g");
-GAPInput
-    rm -f doc/*.tex
-    rm -f doc/*.aux doc/*.bbl doc/*.blg doc/*.brf doc/*.idx doc/*.ilg doc/*.ind doc/*.log doc/*.out doc/*.pnr doc/*.tst
-elif [ -f doc/make_doc ] ; then
-    notice "Copying GAP package documentation for archives (using doc/make_doc)"
-    cp -r "$SRC_DIR/doc" .
-    cp -r "$SRC_DIR/htm" .
-    rm -f doc/*.aux doc/*.bbl doc/*.blg doc/*.brf doc/*.idx doc/*.ilg doc/*.ind doc/*.log doc/*.out doc/*.pnr doc/*.tst
 fi
 
 # make sure every file is readable


### PR DESCRIPTION
Is there a good reason why `.release` should be run _before_ attempting to build the package documentation for the second time, rather than _after_?

Running `.release` after building the documentation would resolve a problem for the Semigroups package (https://github.com/semigroups/Semigroups/issues/778). Currently, we use `.release` to fix more links to other manuals of the kind in #83 (although unlike in #83, we make them into web URLs in the package archive version of the manual, **and** in the website version). Under the current ordering, we therefore have to build the manual ourselves, and we have to take measures to avoid `release-gap-package` from re-building the documentation and overwriting all of our 'fixes'. To do this, we delete `makedoc.g`, which is not ideal.

You can see all of this at:
https://github.com/semigroups/Semigroups/blob/5b25849d0c0d281fac83c216473e6f5d43b35acd/.release#L72-L104

If the order of `.release` and compiling the manuals for a second time were reversed, we could retain the `makedoc.g` file in the release archive, and we could get rid of our (copied from ReleaseTools) code for compiling the Semigroups manual from our `.release` file.