### PR TITLE
Make catching errors in run_gap more robust

### DIFF
--- a/release-gap-package
+++ b/release-gap-package
@@ -101,13 +101,13 @@ run_gap() {
   # for people whose gap script is broken (by not honoring -A, thus loading
   # Browse, which inserts that extra character). I am looking at you,
   # Sebastian!
+  mkdir -p "$TMP_DIR"
   gap_output=$( \
     (echo 'OnBreak:=function() Print("FATAL ERROR"); FORCE_QUIT_GAP(1); end;;' ; cat - ; echo ; echo "FORCE_QUIT_GAP(0);") \
     | $GAP -A -q -b 2>&1 \
-    | tr -d '\r' )
-  mkdir -p "$TMP_DIR"
-  echo "$gap_output" > "$TMP_DIR/gap-error.log"
-  if echo "$gap_output" | grep -q '\(Error\|FATAL ERROR\|Syntax \)' ; then
+    | tr -d '\r' \
+    | tee "$TMP_DIR/gap-error.log" )
+  if grep -q '\(Error\|FATAL ERROR\|Syntax \)' "$TMP_DIR/gap-error.log" ; then
     error "there was an error running GAP, see $TMP_DIR/gap-error.log"
   fi
 }


### PR DESCRIPTION
Some shells (dash, zsh) enable interpretation of backslash escapes for "echo" by default. If "$gap_output" contains "\c" this leads to truncated output. We could disable interpretation of backslash escapes explicitly by passing "-E" to echo, but using "tee" seems more robust in general.