### PR TITLE
Prepend basename (package name and version) to upload name of manual

### DIFF
--- a/release-gap-package
+++ b/release-gap-package
@@ -679,7 +679,7 @@ echo ""
 
 for PDFFile in $PDFFiles ; do
     FULLNAME="$TMP_DIR/$BASENAME/$PDFFile"
-    UPLOADNAME=$(echo "${PDFFile#doc/}" | sed 's;/;-;g')
+    UPLOADNAME=$BASENAME-$(echo "${PDFFile#doc/}" | sed 's;/;-;g')
     if [ ! -f "$FULLNAME" ] ; then
         error "could not find PDF"
     fi


### PR DESCRIPTION
This is more similar to the situation before 8caef1d3 and allows to better keep track of downloaded manuals locally.